### PR TITLE
Add renderer GPU timepoint support to the graph

### DIFF
--- a/graphdata.c
+++ b/graphdata.c
@@ -159,6 +159,7 @@ output_graph_destroy(struct output_graph *og)
 	line_graph_release(&og->delay_line);
 	line_graph_release(&og->submit_line);
 	line_graph_release(&og->gpu_line);
+	line_graph_release(&og->renderer_gpu_line);
 	transition_set_release(&og->begins);
 	transition_set_release(&og->posts);
 	vblank_set_release(&og->vblanks);
@@ -534,6 +535,9 @@ output_graph_to_svg(struct output_graph *og, struct svg_context *ctx)
 	if (line_graph_to_svg(&og->gpu_line, ctx) < 0)
 		return ERROR;
 
+	if (line_graph_to_svg(&og->renderer_gpu_line, ctx) < 0)
+		return ERROR;
+
 	if (transition_set_to_svg(&og->begins, ctx,
 				  og->delay_line.y, og->submit_line.y) < 0)
 		return ERROR;
@@ -760,6 +764,9 @@ graph_data_init_draw(struct graph_data *gdata, double *width, double *height)
 		y += line_step;
 
 		og->gpu_line.y = y;
+		y += line_step;
+
+		og->renderer_gpu_line.y = y;
 		y += line_step * 1.5;
 
 		for (upg = og->updates; upg; upg = upg->next)

--- a/parse.c
+++ b/parse.c
@@ -437,3 +437,19 @@ get_object_info_from_timepoint(struct parse_context *ctx,
 	return lookup_table_get(&ctx->idmap, id);
 }
 
+struct timespec
+get_timespec_from_timepoint(struct parse_context *ctx,
+			    struct json_object *jobj, const char *member)
+{
+	struct json_object *mem_jobj;
+	struct timespec ts;
+
+	timespec_invalidate(&ts);
+
+	if (!json_object_object_get_ex(jobj, member, &mem_jobj))
+		return ts;
+
+	parse_timespec(&ts, mem_jobj);
+
+	return ts;
+}

--- a/style.css
+++ b/style.css
@@ -9,7 +9,8 @@ text[class~="output_label"] {
 
 g[class~="delay_line"] path,
 g[class~="submit_line"] path,
-g[class~="gpu_line"] path {
+g[class~="gpu_line"] path,
+g[class~="renderer_gpu_line"] path {
 	stroke: black;
 	stroke-width: 5;
 }

--- a/wesgr.h
+++ b/wesgr.h
@@ -103,6 +103,7 @@ struct output_graph {
 	struct line_graph delay_line;
 	struct line_graph submit_line;
 	struct line_graph gpu_line;
+	struct line_graph renderer_gpu_line;
 	struct transition_set begins;
 	struct transition_set posts;
 	struct vblank_set vblanks;
@@ -117,6 +118,7 @@ struct output_graph {
 	struct timespec last_begin;
 	struct timespec last_posted;
 	struct timespec last_exit_loop;
+	struct timespec last_renderer_gpu_begin;
 };
 
 struct graph_data {
@@ -213,6 +215,10 @@ parse_context_process_object(struct parse_context *ctx,
 
 struct object_info *
 get_object_info_from_timepoint(struct parse_context *ctx,
+			       struct json_object *jobj, const char *member);
+
+struct timespec
+get_timespec_from_timepoint(struct parse_context *ctx,
 			       struct json_object *jobj, const char *member);
 
 static inline void


### PR DESCRIPTION
Weston recently gained support for emitting begin and end timepoints for
GPU rendering in the timeline. Use the timepoints, if available, to
display line blocks in the graph to represent the GPU rendering
operations.