### PR TITLE
handler: Verify output from get_object_info_from_timepoint()

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -503,7 +503,7 @@ core_commit_damage(struct parse_context *ctx, const struct timespec *ts,
 	struct surface_graph_list *sgl;
 
 	surface = get_object_info_from_timepoint(ctx, jobj, "ws");
-	if (surface->type != TYPE_WESTON_SURFACE)
+	if (!surface || surface->type != TYPE_WESTON_SURFACE)
 		return ERROR;
 
 	sgl = get_surface_graph_list_default(ctx, &surface->info.ws);
@@ -535,7 +535,7 @@ core_flush_damage(struct parse_context *ctx, const struct timespec *ts,
 	struct surface_graph_list *sgl;
 
 	surface = get_object_info_from_timepoint(ctx, jobj, "ws");
-	if (surface->type != TYPE_WESTON_SURFACE)
+	if (!surface || surface->type != TYPE_WESTON_SURFACE)
 		return ERROR;
 
 	update = surface->info.ws.open_update;


### PR DESCRIPTION
Should verify the output returned by get_object_info_from_timepoint(),
before trying to use it. Make(s) wesgr a little more resilient at "malformed"
JSONs.

Signed-off-by: Marius Vlad <marius.vlad@collabora.com>