### PR TITLE
wesgr: Display err no when parsing fails

### DIFF
--- a/wesgr.c
+++ b/wesgr.c
@@ -127,7 +127,7 @@ parse_file(const char *name, struct parse_context *ctx)
 		}
 
 		if (!jobj) {
-			fprintf(stderr, "JSON parse failure\n");
+			fprintf(stderr, "JSON parse failure: %d\n", jerr);
 			break;
 		}
 


### PR DESCRIPTION
Not that it helps that much but it is at least some clue where is
the problem in the JSON. Works best on malformed JSONs.

Signed-off-by: Marius Vlad <marius.vlad@collabora.com>